### PR TITLE
Add optional next year and previous year options for calendar navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,10 @@ return [
         ],
         'buttons' => [
             'today' => \Carbon\Carbon::today()->format('d M'),
+            'hideYearNavigation' => false,
             'icons' => [
+                'previousYear' => 'heroicon-o-chevron-double-left',
+                'nextYear' => 'heroicon-o-chevron-double-right',
                 'previousMonth' => 'heroicon-o-chevron-left',
                 'nextMonth' => 'heroicon-o-chevron-right',
                 'createEvent' => 'heroicon-o-plus'

--- a/config/timex.php
+++ b/config/timex.php
@@ -75,7 +75,10 @@ return [
         'buttons' => [
             'today' => 'D MMM',
             'outlined' => true,
+            'hideYearNavigation' => false,
             'icons' => [
+                'previousYear' => 'heroicon-o-chevron-double-left',
+                'nextYear' => 'heroicon-o-chevron-double-right',
                 'previousMonth' => 'heroicon-o-chevron-left',
                 'nextMonth' => 'heroicon-o-chevron-right',
                 'createEvent' => 'heroicon-o-plus'

--- a/src/Calendar/Month.php
+++ b/src/Calendar/Month.php
@@ -26,7 +26,9 @@ class Month extends Component
         'modelUpdated' => 'loaded',
         'onTodayClick' => 'onTodayClick',
         'onPrevClick' => 'onPreviousMonthClick',
-        'onNextClick' => 'onNextMonthClick'
+        'onNextClick' => 'onNextMonthClick',
+        'onNextYearClick' => 'onNextYearClick',
+        'onPrevYearClick' => 'onPreviousYearClick',
     ];
 
 
@@ -117,6 +119,24 @@ class Month extends Component
     public function onNextMonthClick()
     {
         $this->today = $this->today->addMonth();
+        $this->monthName = $this->today->monthName;
+        $this->setCalendar();
+        $this->loaded();
+        $this->emitUp('monthNameChanged',$this->monthName,$this->today->year);
+    }
+
+    public function onNextYearClick()
+    {
+        $this->today = $this->today->addYear();
+        $this->monthName = $this->today->monthName;
+        $this->setCalendar();
+        $this->loaded();
+        $this->emitUp('monthNameChanged',$this->monthName,$this->today->year);
+    }
+
+    public function onPreviousYearClick()
+    {
+        $this->today = $this->today->subYear();
         $this->monthName = $this->today->monthName;
         $this->setCalendar();
         $this->loaded();

--- a/src/Pages/Timex.php
+++ b/src/Pages/Timex.php
@@ -118,27 +118,44 @@ class Timex extends Page
                             ->color('danger')
                             ->action('deleteEvent')
                             ->cancel()
-                    ]),
-                Action::make('prev')
-                    ->size('sm')
-                    ->icon(config('timex.pages.buttons.icons.previousMonth'))
-                    ->extraAttributes(['class' => '-mr-2 -ml-1'])
-                    ->outlined(config('timex.pages.buttons.outlined'))
-                    ->disableLabel()
-                    ->action(fn() => $this->emit('onPrevClick')),
-                Action::make('today')
-                    ->size('sm')
-                    ->outlined(config('timex.pages.buttons.outlined'))
-                    ->extraAttributes(['class' => '-ml-1 -mr-1'])
-                    ->label(Carbon::today()->isoFormat(config('timex.pages.buttons.today')))
-                    ->action(fn() => $this->emit('onTodayClick')),
-                Action::make('next')
-                    ->size('sm')
-                    ->icon(config('timex.pages.buttons.icons.nextMonth'))
-                    ->extraAttributes(['class' => '-ml-2'])
-                    ->outlined(config('timex.pages.buttons.outlined'))
-                    ->disableLabel()
-                    ->action(fn() => $this->emit('onNextClick')),
+                        ]),
+                        Action::make('prev-year')
+                            ->size('sm')
+                            ->icon(config('timex.pages.buttons.icons.prevYear'))
+                            ->extraAttributes(['class' => '-ml-2'])
+                            ->outlined(config('timex.pages.buttons.outlined'))
+                            ->disableLabel()
+                            ->hidden(config('timex.pages.buttons.hideYearNavigation'))
+                            ->action(fn() => $this->emit('onPreviousYearClick')),
+                        Action::make('prev')
+                            ->size('sm')
+                            ->icon(config('timex.pages.buttons.icons.previousMonth'))
+                            ->extraAttributes(['class' => '-mr-2 -ml-1'])
+                            ->outlined(config('timex.pages.buttons.outlined'))
+                            ->disableLabel()
+                            ->action(fn() => $this->emit('onPrevClick')),
+                        Action::make('today')
+                            ->size('sm')
+                            ->outlined(config('timex.pages.buttons.outlined'))
+                            ->extraAttributes(['class' => '-ml-1 -mr-1'])
+                            ->label(Carbon::today()->isoFormat(config('timex.pages.buttons.today')))
+                            ->action(fn() => $this->emit('onTodayClick')),
+                        Action::make('next')
+                            ->size('sm')
+                            ->icon(config('timex.pages.buttons.icons.nextMonth'))
+                            ->extraAttributes(['class' => '-ml-2'])
+                            ->outlined(config('timex.pages.buttons.outlined'))
+                            ->disableLabel()
+                            ->action(fn() => $this->emit('onNextClick')),
+                    Action::make('next-year')
+                            ->size('sm')
+                            ->icon(config('timex.pages.buttons.icons.nextYear'))
+                            ->extraAttributes(['class' => '-ml-2'])
+                            ->outlined(config('timex.pages.buttons.outlined'))
+                            ->disableLabel()
+                            ->hidden(config('timex.pages.buttons.hideYearNavigation'))
+                            ->action(fn() => $this->emit('onNextYearClick')),
+
         ];
     }
 


### PR DESCRIPTION
Started using this plugin and think it's great. I'm hoping to use it for part of a booking management system and noticed for my use case it would be good to have a next and previous year option which wasn't available without Forking your repo. Always good to give back to great projects so hopefully its something you can include.